### PR TITLE
第6章 テスト不足に気づいたら

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -9,5 +9,5 @@
 - [ ] 他オブジェクトとの等価比較
 - [x] ~~5CHF * 2 = 10CHF~~
 - [ ] DollarとFrancの重複
-- [ ] equalsの一般化
+- [x] ~~equalsの一般化~~
 - [ ] timesの一般化

--- a/app/money/src/Dollar.php
+++ b/app/money/src/Dollar.php
@@ -2,19 +2,15 @@
 
 namespace Money;
 
-class Dollar
+class Dollar extends Money
 {
-    public function __construct(private readonly int $amount)
+    public function __construct(int $amount)
     {
+        parent::__construct($amount);
     }
 
     public function times(int $multiplier): self
     {
         return new self($this->amount * $multiplier);
-    }
-
-    public function equals(object $object): bool
-    {
-        return $this->amount == $object->amount;
     }
 }

--- a/app/money/src/Franc.php
+++ b/app/money/src/Franc.php
@@ -2,19 +2,15 @@
 
 namespace Money;
 
-class Franc
+class Franc extends Money
 {
-    public function __construct(private readonly int $amount)
+    public function __construct(int $amount)
     {
+        parent::__construct($amount);
     }
 
     public function times(int $multiplier): self
     {
         return new self($this->amount * $multiplier);
-    }
-
-    public function equals(object $object): bool
-    {
-        return $this->amount == $object->amount;
     }
 }

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Money;
+
+class Money
+{
+    public function __construct(protected readonly int $amount)
+    {
+    }
+
+    public function equals(Money $object): bool
+    {
+        return $this->amount == $object->amount;
+    }
+}

--- a/app/money/tests/Unit/MoneyTest.php
+++ b/app/money/tests/Unit/MoneyTest.php
@@ -19,6 +19,9 @@ class MoneyTest extends TestCase
     {
         $this->assertTrue((new Dollar(5))->equals(new Dollar(5)));
         $this->assertFalse((new Dollar(5))->equals(new Dollar(6)));
+
+        $this->assertTrue((new Franc(5))->equals(new Franc(5)));
+        $this->assertFalse((new Franc(5))->equals(new Franc(6)));
     }
 
     public function testFrancMultiplication()


### PR DESCRIPTION
# 思ったこと
DollarとFrancにあったequalsメソッドをMoneyに引き上げる上で元々equalsをselfなどを使って一般化できるようにしていたから本ほど手数をかけなくてもすんなりできた。  
ただPHPはオブジェクトのキャストができなかったので引数の型をMoneyに変えてそこでキャストをするようにした