### PR TITLE
第8章 実装を隠す

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -13,3 +13,4 @@
 - [ ] timesの一般化
 - [x] ~~FrancとDollarを比較する~~
 - [ ] 通貨の概念
+- [ ] testFrancMultiplicationを削除する？

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -2,8 +2,10 @@
 
 namespace Money;
 
-class Money
+abstract class Money
 {
+    abstract public function times(int $multiplier): Money;
+
     public function __construct(protected readonly int $amount)
     {
     }
@@ -12,5 +14,15 @@ class Money
     {
         return $this->amount == $money->amount
             && $this::class === $money::class;
+    }
+
+    public static function dollar(int $amount): Money
+    {
+        return new Dollar($amount);
+    }
+
+    public static function franc(int $amount): Money
+    {
+        return new Franc($amount);
     }
 }

--- a/app/money/tests/Unit/MoneyTest.php
+++ b/app/money/tests/Unit/MoneyTest.php
@@ -4,32 +4,33 @@ namespace Money\Tests\Unit;
 
 use Money\Dollar;
 use Money\Franc;
+use Money\Money;
 use PHPUnit\Framework\TestCase;
 
 class MoneyTest extends TestCase
 {
     public function testMultiplication(): void
     {
-        $five = new Dollar(5);
-        $this->assertEquals(new Dollar(10), $five->times(2));
-        $this->assertEquals(new Dollar(15), $five->times(3));
+        $five = Money::dollar(5);
+        $this->assertEquals(Money::dollar(10), $five->times(2));
+        $this->assertEquals(Money::dollar(15), $five->times(3));
     }
 
     public function testEquality()
     {
-        $this->assertTrue((new Dollar(5))->equals(new Dollar(5)));
-        $this->assertFalse((new Dollar(5))->equals(new Dollar(6)));
+        $this->assertTrue((Money::dollar(5))->equals(Money::dollar(5)));
+        $this->assertFalse((Money::dollar(5))->equals(Money::dollar(6)));
 
-        $this->assertTrue((new Franc(5))->equals(new Franc(5)));
-        $this->assertFalse((new Franc(5))->equals(new Franc(6)));
+        $this->assertTrue((Money::franc(5))->equals(Money::franc(5)));
+        $this->assertFalse((Money::franc(5))->equals(Money::franc(6)));
 
-        $this->assertFalse((new Dollar(5))->equals(new Franc(5)));
+        $this->assertFalse((Money::dollar(5))->equals(Money::franc(5)));
     }
 
     public function testFrancMultiplication()
     {
-        $five = new Franc(5);
-        $this->assertEquals(new Franc(10), $five->times(2));
-        $this->assertEquals(new Franc(15), $five->times(3));
+        $five = Money::franc(5);
+        $this->assertEquals(Money::franc(10), $five->times(2));
+        $this->assertEquals(Money::franc(15), $five->times(3));
     }
 }


### PR DESCRIPTION
# 思ったこと
PHPで型などはあらかじめ揃えておいたので本の意図とは違う状態になってしまっているが、共通化がすんなりできている。  
timesメソッドも全く同じ形になっているのでこれはいい癖になっていると思う。  

Moneyクラスにあるdollarやfrancはクラスが増えるたびにメソッドを増やす必要がるので冗長に感じたが、こんなもん？