### PR TITLE
第11章 不要になったら消す

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -13,4 +13,4 @@
 - [x] ~~timesの一般化~~
 - [x] ~~FrancとDollarを比較する~~
 - [x] ~~通貨の概念~~
-- [ ] testFrancMultiplicationを削除する？
+- [x] ~~testFrancMultiplicationを削除する？~~

--- a/app/money/src/Dollar.php
+++ b/app/money/src/Dollar.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Money;
-
-class Dollar extends Money
-{
-}

--- a/app/money/src/Franc.php
+++ b/app/money/src/Franc.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Money;
-
-class Franc extends Money
-{
-}

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -23,12 +23,12 @@ class Money
 
     public static function dollar(int $amount): Money
     {
-        return new Dollar($amount, 'USD');
+        return new Money($amount, 'USD');
     }
 
     public static function franc(int $amount): Money
     {
-        return new Franc($amount, 'CHF');
+        return new Money($amount, 'CHF');
     }
 
     public function currency(): string

--- a/app/money/tests/Unit/MoneyTest.php
+++ b/app/money/tests/Unit/MoneyTest.php
@@ -2,8 +2,6 @@
 
 namespace Money\Tests\Unit;
 
-use Money\Dollar;
-use Money\Franc;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 
@@ -21,27 +19,12 @@ class MoneyTest extends TestCase
         $this->assertTrue((Money::dollar(5))->equals(Money::dollar(5)));
         $this->assertFalse((Money::dollar(5))->equals(Money::dollar(6)));
 
-        $this->assertTrue((Money::franc(5))->equals(Money::franc(5)));
-        $this->assertFalse((Money::franc(5))->equals(Money::franc(6)));
-
         $this->assertFalse((Money::dollar(5))->equals(Money::franc(5)));
-    }
-
-    public function testFrancMultiplication()
-    {
-        $five = Money::franc(5);
-        $this->assertObjectEquals(Money::franc(10), $five->times(2));
-        $this->assertObjectEquals(Money::franc(15), $five->times(3));
     }
 
     public function testCurrency()
     {
         $this->assertEquals('USD', (Money::dollar(1))->currency());
         $this->assertEquals('CHF', (Money::franc(1))->currency());
-    }
-
-    public function testDifferentClassEquality()
-    {
-        $this->assertTrue((new Money(5, 'CHF'))->equals(new Franc(5, 'CHF')));
     }
 }


### PR DESCRIPTION
# 思ったこと
MoneyTestクラスのFranc系のテストを消してしまったがここは少し疑問...  
実装を書いているからMoney::francとMoney::dollarが似たようなファクトリメソッドということがわかるが、何も知らない人からしたらfrancが何か分からないので残しておく必要があると感じた。  
また、現状だとMoney::francメソッドが変更された時にその正当性を評価するテストがないのも良くない.  

**追記**
testEqualityでfrancとdollarが一緒じゃないというテストをしているからこれでOKという認識？  
→ assertTrueのテストであればありかもと思ったが、assertFalseのテストで正当性は担保できないと思う...